### PR TITLE
Integrate Travis using industrial_ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: required
+dist: trusty
+language: generic
+
+compiler:
+  - gcc
+
+notifications:
+  email:
+    on_failure: always
+
+env:
+  matrix:
+    - USE_DEB=true
+      ROS_DISTRO="indigo"
+      ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true
+      ROS_DISTRO="indigo"
+      ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+
+script:
+  - source .ci_config/travis.sh


### PR DESCRIPTION
As per subject.

This is the default ros-i `.travis.yml` copied to this repository.
