### PR TITLE
Fix BMDA3 RSI launch file

### DIFF
--- a/motoman_bmda3_support/launch/robot_interface_streaming_bmda3.launch
+++ b/motoman_bmda3_support/launch/robot_interface_streaming_bmda3.launch
@@ -5,14 +5,17 @@
    - 6 joints
 
   Usage:
-    robot_interface_streaming_bmda3.launch robot_ip:=<value>
+    robot_interface_streaming_bmda3.launch robot_ip:=<value> controller:=<fs100|dx100>
 -->
 <launch>
   <arg name="robot_ip" />
 
+  <!-- controller: Controller name (fs100 or dx100) -->
+  <arg name="controller" />
+
   <rosparam command="load" file="$(find motoman_bmda3_support)/config/joint_names_bmda3.yaml" />
 
-  <include file="$(find motoman_driver)/launch/robot_interface_streaming.launch">
-    <arg name="robot_ip"   value="$(arg robot_ip)" />
+  <include file="$(find motoman_driver)/launch/robot_interface_streaming_$(arg controller).launch">
+    <arg name="robot_ip" value="$(arg robot_ip)" />
   </include>
 </launch>

--- a/motoman_bmda3_support/test/launch_test.xml
+++ b/motoman_bmda3_support/test/launch_test.xml
@@ -27,6 +27,7 @@
 -->
 <launch>
   <arg name="req_arg" value="default"/>
+  <arg name="controller" value="fs100"/>
 
   <group ns="load_bmda3">
     <include file="$(find motoman_bmda3_support)/launch/load_bmda3.launch"/>
@@ -40,12 +41,14 @@
   <group ns="robot_interface_streaming_bmda3">
     <include file="$(find motoman_bmda3_support)/launch/robot_interface_streaming_bmda3.launch">
       <arg name="robot_ip" value="$(arg req_arg)" />
+      <arg name="controller" value="$(arg controller)" />
     </include>
   </group>
 
   <group ns="robot_state_visualize_bmda3">
     <include file="$(find motoman_bmda3_support)/launch/robot_state_visualize_bmda3.launch">
       <arg name="robot_ip" value="$(arg req_arg)" />
+      <arg name="controller" value="$(arg controller)" />
     </include>
   </group>
 


### PR DESCRIPTION
Was missing the `controller` arg leading to problems after the restructuring by @shaun-edwards.
