### PR TITLE
'fix' robot_pkg_gen Python setup: motoman_robot_pkg_gen is not a Python pkg

### DIFF
--- a/motoman_robot_pkg_gen/setup.py
+++ b/motoman_robot_pkg_gen/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
-    packages=['motoman_robot_pkg_gen'],
+    scripts=['scripts/package_generator']
 )
 
 setup(**d)


### PR DESCRIPTION
As per subject.

