### PR TITLE
Add a support level badge to repository level readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Motoman Experimental
 
+[![support level: community](https://img.shields.io/badge/support%20level-community-lightgray.png)](http://rosindustrial.org/news/2016/10/7/better-supporting-a-growing-ros-industrial-software-platform)
+
 Experimental packages for Motoman manipulators within [ROS-Industrial][].
 See the [ROS wiki][] page for more information.
 


### PR DESCRIPTION
Related PR: ros-industrial/motoman#192.

I went with `community` here (instead of `consortium / vendor`) as this is the experimental repository. I'm actually not sure whether that matters, so am fine with changing it to `consortium / vendor` if needed.
