### PR TITLE
Replace `xacro.py` to `xacro --inorder`

### DIFF
--- a/motoman_bmda3_support/launch/load_bmda3.launch
+++ b/motoman_bmda3_support/launch/load_bmda3.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find motoman_bmda3_support)/urdf/bmda3.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_bmda3_support)/urdf/bmda3.xacro'" />
 </launch>

--- a/motoman_csda10f_support/launch/load_csda10f.launch
+++ b/motoman_csda10f_support/launch/load_csda10f.launch
@@ -1,4 +1,4 @@
 
 <launch>
-	<param name="robot_description" command="$(find xacro)/xacro.py '$(find motoman_csda10f_support)/urdf/csda10f.xacro'" />
+	<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_csda10f_support)/urdf/csda10f.xacro'" />
 </launch>

--- a/motoman_mpl_support/launch/load_mpl80.launch
+++ b/motoman_mpl_support/launch/load_mpl80.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0" ?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find motoman_mpl_support)/urdf/mpl80.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find motoman_mpl_support)/urdf/mpl80.xacro'" />
 </launch>


### PR DESCRIPTION
This PR fixes https://github.com/ros-industrial/industrial_training/issues/220 issue.

Environment:
- OS: Ubuntu 16.04
- ROS: Kinetic