### PR TITLE
sia5d:  add boolean argument "headless" for skipping launch of rviz

### DIFF
--- a/motoman_sia5d_moveit_config/launch/moveit_planning_execution.launch
+++ b/motoman_sia5d_moveit_config/launch/moveit_planning_execution.launch
@@ -12,6 +12,7 @@
   <!-- the "sim" argument controls whether we connect to a Simulated or Real robot -->
   <!--  - if sim=false, robot_ip and controller arguments are required -->
   <arg name="sim" default="true" />
+  <arg name="headless" default="false" />
   <arg name="robot_ip" unless="$(arg sim)" doc="IP of controller" />
   <arg name="controller" unless="$(arg sim)"
        doc="Series of the controller (dx100, dx200, fs100 or yrc1000)" />
@@ -43,9 +44,11 @@
     <arg name="publish_monitored_planning_scene" value="true" />
   </include>
 
-  <include file="$(find motoman_sia5d_moveit_config)/launch/moveit_rviz.launch">
-    <arg name="config" value="true"/>
-  </include>
+  <group unless="$(arg headless)">
+    <include file="$(find motoman_sia5d_moveit_config)/launch/moveit_rviz.launch">
+      <arg name="config" value="true"/>
+    </include>
+  </group>
 
   <include file="$(find motoman_sia5d_moveit_config)/launch/default_warehouse_db.launch" />
 

--- a/motoman_sia5d_moveit_config/launch/moveit_planning_execution.launch
+++ b/motoman_sia5d_moveit_config/launch/moveit_planning_execution.launch
@@ -30,7 +30,6 @@
   <!--   - this typically includes: robot_state, motion_interface, and joint_trajectory_action nodes -->
   <!--   - replace these calls with appropriate robot-specific calls or launch files -->
   <group unless="$(arg sim)">
-    <node pkg="rosservice" type="rosservice" name="robot_enable" args="call --wait /robot_enable"/>
     <include file="$(find motoman_sia5d_support)/launch/robot_interface_streaming_sia5d.launch" >
       <arg name="robot_ip" value="$(arg robot_ip)"/>
       <arg name="controller" value="$(arg controller)"/>


### PR DESCRIPTION
Added an argument that allows for skipping the launch of rviz. This is useful for when the launch-file is executed on a headless machine. This modification should be compatible with other scripts using the launch-file `moveit_planning_execution.launch` as the default value for the parameter is set to false. 